### PR TITLE
fix exception when get method has parameters

### DIFF
--- a/src/Util/CallbackHelper.php
+++ b/src/Util/CallbackHelper.php
@@ -76,21 +76,36 @@ class CallbackHelper
         return null;
     }
 
-    public static function tryGetProperty(object $obj, string $prop, mixed $default = null): mixed
+    /**
+     * Attempts to retrieve the value of a property from an object. If a getter method exists for the property,
+     * it will be invoked. Otherwise, it will attempt to access the property directly or via magic methods.
+     * If the property is not found or an error occurs, the default value is returned.
+     *
+     * @param object     $obj The object from which the property is retrieved.
+     * @param string     $prop The name of the property to retrieve.
+     * @param mixed      $default The default value to return if the property cannot be retrieved.
+     *
+     * @return mixed          The value of the property, if found; otherwise, the default value.
+     */
+    public static function tryGetProperty(object $obj, string $prop, mixed  $default = null): mixed
     {
-        try
-        {
-            $getMethod = 'get' . \ucfirst($prop);
+        $getMethod = 'get' . \ucfirst($prop);
 
-            if (\method_exists($obj, $getMethod))
+        if (\method_exists($obj, $getMethod))
+        {
+            try
             {
                 return $obj->{$getMethod}();
             }
-        }
-        /** @mago-expect lint:no-empty-catch-clause This is intentional. */
-        catch (\Throwable)
-        {
-            // Ignore exceptions from getter methods
+            /** @mago-expect lint:no-empty-catch-clause This is intentional. */
+            catch (\ArgumentCountError)
+            {
+                // Skip to direct property access if the getter method expects arguments.
+            }
+            catch (\Throwable)
+            {
+                return $default;
+            }
         }
 
         if (\property_exists($obj, $prop) || \method_exists($obj, '__get'))

--- a/src/Util/CallbackHelper.php
+++ b/src/Util/CallbackHelper.php
@@ -78,15 +78,23 @@ class CallbackHelper
 
     public static function tryGetProperty(object $obj, string $prop, mixed $default = null): mixed
     {
-        try {
-            if (\method_exists($obj, 'get' . \ucfirst($prop))) {
-                return $obj->{'get' . \ucfirst($prop)}();
+        try
+        {
+            $getMethod = 'get' . \ucfirst($prop);
+
+            if (\method_exists($obj, $getMethod))
+            {
+                return $obj->{$getMethod}();
             }
-        } catch (\Throwable) {
+        }
+        /** @mago-expect lint:no-empty-catch-clause This is intentional. */
+        catch (\Throwable)
+        {
             // Ignore exceptions from getter methods
         }
 
-        if (\property_exists($obj, $prop) || \method_exists($obj, '__get')) {
+        if (\property_exists($obj, $prop) || \method_exists($obj, '__get'))
+        {
             return $obj->{$prop};
         }
 

--- a/src/Util/CallbackHelper.php
+++ b/src/Util/CallbackHelper.php
@@ -78,8 +78,12 @@ class CallbackHelper
 
     public static function tryGetProperty(object $obj, string $prop, mixed $default = null): mixed
     {
-        if (\method_exists($obj, 'get' . \ucfirst($prop))) {
-            return $obj->{'get' . \ucfirst($prop)}();
+        try {
+            if (\method_exists($obj, 'get' . \ucfirst($prop))) {
+                return $obj->{'get' . \ucfirst($prop)}();
+            }
+        } catch (\Throwable) {
+            // Ignore exceptions from getter methods
         }
 
         if (\property_exists($obj, $prop) || \method_exists($obj, '__get')) {


### PR DESCRIPTION
Got an issue with the getAlias method of DC_Multilingual as this has a lang parameter. 
This fixed it, but maybe this is not the best way, so I don't merged it to main.