### PR TITLE
Fix Service Subscriber Incompatibility with AbstractProjector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.2",
         "ext-mbstring": "*",
-        "friendsofsymfony/http-cache-bundle": "^3.0",
+        "friendsofsymfony/http-cache-bundle": "^2.17 || ^3.0",
         "contao/core-bundle": "^4.13 || ^5.0",
         "composer/semver": "^3.4",
         "doctrine/dbal": "^2.13 || ^3.0 || ^4.0",

--- a/src/Engine/Projector/AbstractProjector.php
+++ b/src/Engine/Projector/AbstractProjector.php
@@ -20,14 +20,18 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
-use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 abstract class AbstractProjector implements ProjectorInterface, ServiceSubscriberInterface
 {
-    use ServiceSubscriberTrait;
-
     protected ContainerInterface $container;
+
+    #[Required]
+    public function setContainer(ContainerInterface $container): void
+    {
+        $this->container = $container;
+    }
 
     public static function getSubscribedServices(): array
     {


### PR DESCRIPTION
This pull request introduces compatibility improvements for dependency versions and updates to dependency injection in the `AbstractProjector` class. The most important changes are:

**Dependency compatibility:**

* Updated the `composer.json` to allow installation of either version 2.17 or 3.0 of the `friendsofsymfony/http-cache-bundle`, increasing flexibility for different environments.

**Dependency injection and service container handling:**

* Removed the use of the `ServiceSubscriberTrait` in `AbstractProjector` and replaced it with an explicit `setContainer` method annotated with `#[Required]` for dependency injection, improving clarity and compatibility with Symfony's recommended practices.

* Fixes #11