### PR TITLE
Fix ArchiveElement and form value data, extend ChoiceBuilder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,56 @@
+# Auto-detect text files and normalize line endings on commit
+* text=auto eol=lf
+
+# Explicit text files
+*.php          text diff=php
+*.html         text diff=html
+*.html.twig    text
+*.twig         text
+*.css          text diff=css
+*.scss         text diff=css
+*.js           text
+*.json         text
+*.yaml         text
+*.yml          text
+*.xml          text
+*.xliff        text
+*.svg          text
+*.md           text diff=markdown
+*.neon         text
+*.toml         text
+*.dist         text
+*.sh           text eol=lf
+Makefile       text eol=lf
+Dockerfile     text eol=lf
+
+# Binary files
+*.png          binary
+*.jpg          binary
+*.jpeg         binary
+*.gif          binary
+*.ico          binary
+*.webp         binary
+*.woff         binary
+*.woff2        binary
+*.ttf          binary
+*.eot          binary
+*.otf          binary
+*.pdf          binary
+
+# Files excluded from the Composer distribution archive
+/.claude              export-ignore
+/.dockerignore        export-ignore
+/.editorconfig        export-ignore
+/.gitattributes       export-ignore
+/.github              export-ignore
+/.gitignore           export-ignore
+/.idea                export-ignore
+/AGENTS.md            export-ignore
+/Makefile             export-ignore
+/docker               export-ignore
+/docker-compose.yml   export-ignore
+/docs                 export-ignore
+/mago.toml            export-ignore
+/phpstan.neon         export-ignore
+/phpunit.xml.dist     export-ignore
+/tests                export-ignore

--- a/.github/workflows/mago.yaml
+++ b/.github/workflows/mago.yaml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Setup Mago
         uses: nhedger/setup-mago@v1
+        with:
+          version: '1.24.0'
 
       - name: Run Mago Lint (PHP 8.2)
         run: mago lint --minimum-fail-level note --reporting-format github

--- a/contao/dca/tl_flare_filter.php
+++ b/contao/dca/tl_flare_filter.php
@@ -227,6 +227,19 @@ $dca['fields'] = [
         ],
         'sql' => ['type' => 'boolean', 'default' => false],
     ],
+    'useWhitelistForOptionsOnly' => [
+        'exclude' => true,
+        'toggle' => true,
+        'filter' => false,
+        'default' => false,
+        'flag' => DataContainer::SORT_INITIAL_LETTER_DESC,
+        'inputType' => 'checkbox',
+        'eval' => [
+            'submitOnChange' => false,
+            'tl_class' => 'cbx w50 m12'
+        ],
+        'sql' => ['type' => 'boolean', 'default' => false],
+    ],
     'hasEmptyOption' => [
         'exclude' => true,
         'toggle' => true,

--- a/contao/languages/de/tl_flare_filter.php
+++ b/contao/languages/de/tl_flare_filter.php
@@ -58,6 +58,7 @@ $lang['groupWhitelistParents'] = ['Zulässige Eltern-Archive definieren', 'Bitte
 $lang['formatLabel'] = ['Formatierung', 'Bitte wählen Sie eine Formatierung für die Anzeige.'];
 $lang['formatLabel_custom'] = 'Eigene Formatierung';
 $lang['formatLabelCustom'] = ['Eigene Formatierung', 'Bitte geben Sie eine Formatierung für die Anzeige ein.'];
+$lang['useWhitelistForOptionsOnly'] = ['Whitelist nur auf Formularoptionen anwenden', 'Aktiv: Whitelist begrenzt nur die im Filter angezeigten Archive. Ohne Auswahl im Formular werden auch Elemente aus anderen Archiven angezeigt.'];
 ###< archive_legend ###
 
 ###> form_legend ###

--- a/src/Contract/FilterElement/RuntimeValueContract.php
+++ b/src/Contract/FilterElement/RuntimeValueContract.php
@@ -13,7 +13,7 @@ interface RuntimeValueContract
      * Processes and returns a normalized filter value that has been determined at execution runtime,
      *   as opposed to values defined through intrinsic configuration, i.e., in the backend.
      *
-     * The value parameter might have been resolved by a Symfony form component, or set within a Twig template.
+     * The value parameter might have been resolved by a Symfony form component or set within a Twig template.
      *
      * @param mixed $value The value to filter on, which has been determined at runtime.
      * @return mixed The processed value, which will be passed to the filter method upon invocation, where it can

--- a/src/Engine/Projector/InteractiveProjector.php
+++ b/src/Engine/Projector/InteractiveProjector.php
@@ -133,6 +133,7 @@ class InteractiveProjector extends AbstractProjector
 
         $filterElementRegistry = $this->getFilterElementRegistry();
 
+        $data = [];
         foreach ($list->getFilters()->getIterator() as $filterDefinition)
         {
             if (!$filterElement = $filterElementRegistry->get($filterDefinition->getType())?->getService()) {
@@ -172,7 +173,11 @@ class InteractiveProjector extends AbstractProjector
             }
 
             $filterElement->hydrateForm($field, $list, $filterDefinition);
+
+            $data[$filterName] = $field->getData();
         }
+
+        $form->setData(\array_merge($form->getData() ?? [], $data));
     }
 
     protected function mapFormDataToFilterKeys(ListSpecification $list, FormInterface $form): array

--- a/src/Engine/Projector/InteractiveProjector.php
+++ b/src/Engine/Projector/InteractiveProjector.php
@@ -187,7 +187,7 @@ class InteractiveProjector extends AbstractProjector
         {
             $formName = $definition->getAlias();
             if ($formName && \array_key_exists($formName, $formData)) {
-                $values[$key] = $form->get($formName)->getViewData();
+                $values[$key] = $form->get($formName)->getData();
             }
         }
 

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -152,17 +152,15 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
     {
         $values = $this->normalizeFilterValue($value);
 
-        // If no value is selected, and the filter applies not only to form options,
-        //   we must filter by all whitelisted archives.
-        $useFullWhitelist = !$values && !$filter->useWhitelistForOptionsOnly;
+        // If no value is selected, or the empty option is selected, and the filter
+        // applies not only to form options, we must filter by all whitelisted archives.
+        $useFullWhitelist = (!$values || $values === true) && !$filter->useWhitelistForOptionsOnly;
 
-        if ($useFullWhitelist || $values === true)
-            // Empty option selected -> also filter by all whitelisted archives.
-        {
+        if ($useFullWhitelist) {
             return $this->getWhitelistedParents($list, $filter);
         }
 
-        if (!$values) {
+        if (!$values || $values === true) {
             return [];
         }
 

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -48,38 +48,25 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
      */
     public function __invoke(FilterInvocation $inv, FilterQueryBuilder $qb): void
     {
-        $filerValue = $inv->getValue() ?? [];
+        /** @var Model[] $selectedModels */
+        $selectedModels = $inv->getValue() ?? [];
         $inferrer = $this->getPtableInferrer($inv->list);
+
+        if (!$selectedModels)
+        {
+            if ($inv->filter->useWhitelistForOptionsOnly) {
+                return;
+            }
+
+            $qb::abort();
+        }
 
         if ($inferrer->getDcaMainPtable())
         {
-            $filerValueIds = \array_map(static fn (Model $model): int => (int) $model->id, $filerValue);
-            $whitelist = $filerValueIds;
-
-            if (!$inv->filter->isIntrinsic())
-                // Double-check that we are only filtering by whitelisted parents when the filter has a form value
-            {
-                if (!$whitelist = StringUtil::deserialize($inv->filter->whitelistParents, true)) {
-                    throw new FilterException('No whitelisted parents defined.');
-                }
-
-                $allowEmpty = !$inv->filter->hasEmptyOption || $inv->filter->isExpanded;
-
-                if ($filerValueIds && ($allowEmpty || \count($filerValueIds) > 0))
-                    // we expect $filerValue to be an array of parent models
-                    // if the empty option is enabled, an empty array is allowed // todo: double-check this logic
-                {
-                    $whitelist = \array_intersect(\array_map('\intval', $whitelist), $filerValueIds);
-
-                    if (!$whitelist)
-                    {
-                        $qb->abort();
-                    }
-                }
-            }
+            $filerValueIds = \array_map(static fn (Model $model): int => (int) $model->id, $selectedModels);
 
             $qb->where($qb->expr()->in($qb->column('pid'), ':pidIn'))
-                ->setParameter('pidIn', $whitelist, ArrayParameterType::INTEGER);
+                ->setParameter('pidIn', $filerValueIds, ArrayParameterType::INTEGER);
 
             return;
         }
@@ -91,31 +78,16 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         }
 
         /**
-         * ## We are dealing with a _dynamic ptable_ henceforth.
+         * ## = We are dealing with a _dynamic ptable_. ⇒
          */
 
-        $grouped = null;
-        $filerValue = \array_filter((array) $filerValue);
+        $grouped = [];
+        $selectedModels = \array_filter((array) $selectedModels);
 
-        if ($filerValue || (!$inv->filter->isIntrinsic() && $inv->filter->hasEmptyOption))
-            // we expect $filerValue to be an array of values formatted {table}.{id}
-            // if hasEmptyOption is enabled, an empty array is allowed
+        foreach ($selectedModels as $item)
         {
-            $grouped = [];
-
-            foreach ($filerValue as $value)
-            {
-                if ($value instanceof Model) {
-                    $grouped[$value::getTable()][] = $value->id;
-                }
-
-                if (!\is_string($value) || !\str_contains($value, '.')) {  // skip invalid values
-                    continue;
-                }
-
-                [$table, $id] = \explode('.', $value, 2);
-
-                $grouped[$table][] = (int) $id;
+            if ($item instanceof Model) {
+                $grouped[$item::getTable()][] = $item->id;
             }
         }
 
@@ -165,11 +137,17 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         return $this->getParentsFromGroupWhitelistBlob($filter->groupWhitelistParents);
     }
 
+    /**
+     * @return Model[]
+     */
     public function getIntrinsicValue(ListSpecification $list, FilterDefinition $filter): array
     {
         return $this->getWhitelistedParents($list, $filter);
     }
 
+    /**
+     * @return Model[]
+     */
     public function processRuntimeValue(mixed $value, ListSpecification $list, FilterDefinition $filter): array
     {
         $values = $this->normalizeFilterValue($value);
@@ -326,7 +304,11 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
                 ? $filter->formatEmptyOptionCustom
                 : $filter->formatEmptyOption;
 
-            $choices->setEmptyOption($emptyOptionLabel ?: true);
+            $emptyOptionValue = ($filter->isExpanded && $filter->isMultiple)
+                ? ChoicesBuilder::EMPTY_CHOICE_VALUE_ALTERNATIVE
+                : null;
+
+            $choices->setEmptyOption($emptyOptionLabel ?: true, $emptyOptionValue);
         }
 
         if ($ptable = $inferrer->getDcaMainPtable())
@@ -591,6 +573,7 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         };
 
         $data = [];
+        $fetch = [];
 
         foreach ($preselect as $entity)
         {
@@ -623,6 +606,16 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
 
             [$table, $id] = \explode('.', $entity, 2);
 
+            $fetch[$table] ??= [];
+            $fetch[$table][] = (int) $id;
+        }
+
+        foreach ($fetch as $table => $ids)
+        {
+            if (!$ids = \array_unique($ids)) {
+                continue;
+            }
+
             if (!$modelClass = Model::getClassFromTable($table)) {
                 continue;
             }
@@ -631,9 +624,11 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
                 continue;
             }
 
-            if ($model = $modelClass::findByPk($id)) {
-                $data[] = $model;
+            if (!$models = $modelClass::findMultipleByIds($ids)?->getModels()) {
+                continue;
             }
+
+            \array_push($data, ...$models);
         }
 
         $field->setData($data);

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -36,6 +36,8 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
 {
     public const TYPE = 'flare_archive';
 
+    private array $_inferrer = [];
+
     public function __construct(
         private readonly ChoicesBuilderFactory $choicesBuilderFactory,
         private readonly BelongsToRelationElement $relationElement,
@@ -46,35 +48,13 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
      */
     public function __invoke(FilterInvocation $inv, FilterQueryBuilder $qb): void
     {
-        $filerValue = $inv->getValue();
-
-        $inferrable = PtableInferrableFactory::createFromListModelLike($inv->list);
-        $inferrer = new PtableInferrer($inferrable, $inv->list->dc);
-
-        if ($filerValue && !\is_array($filerValue)) {
-            $filerValue = [$filerValue];
-        }
-
-        foreach ($filerValue ?? [] as $value)
-        {
-            if ($value === ChoicesBuilder::EMPTY_CHOICE) {
-                return; // todo: this is a bug, as the whitelisted parents should still be checked
-            }
-
-            if (!$value instanceof Model) {
-                $qb->abort();
-            }
-        }
+        $filerValue = $inv->getValue() ?? [];
+        $inferrer = $this->getPtableInferrer($inv->list);
 
         if ($inferrer->getDcaMainPtable())
         {
-            $filerValueIds = \array_map(static fn (Model $model): int => (int) $model->id, $filerValue ?? []);
+            $filerValueIds = \array_map(static fn (Model $model): int => (int) $model->id, $filerValue);
             $whitelist = $filerValueIds;
-
-            if (!$filerValueIds && $inv->filter->isIntrinsic())
-            {
-                return;
-            }
 
             if (!$inv->filter->isIntrinsic())
                 // Double-check that we are only filtering by whitelisted parents when the filter has a form value
@@ -83,9 +63,9 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
                     throw new FilterException('No whitelisted parents defined.');
                 }
 
-                $selectionRequired = !$inv->filter->isExpanded && !$inv->filter->hasEmptyOption;
+                $allowEmpty = !$inv->filter->hasEmptyOption || $inv->filter->isExpanded;
 
-                if ($filerValueIds && ((!$inv->filter->hasEmptyOption || $inv->filter->isExpanded) || \count($filerValueIds) > 0))
+                if ($filerValueIds && ($allowEmpty || \count($filerValueIds) > 0))
                     // we expect $filerValue to be an array of parent models
                     // if the empty option is enabled, an empty array is allowed // todo: double-check this logic
                 {
@@ -139,13 +119,18 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
             }
         }
 
-        $this->relationElement->filterDynamicPtableField($qb, $inv->filter, 'ptable', 'pid', $grouped);
+        $this->relationElement->filterDynamicPtableField(
+            qb: $qb,
+            filter: $inv->filter,
+            fieldDynamicPtable: 'ptable',
+            fieldPid: 'pid',
+            submittedData: $grouped,
+        );
     }
 
     public function getIntrinsicValue(ListSpecification $list, FilterDefinition $filter): array
     {
-        $inferrable = PtableInferrableFactory::createFromListModelLike($list);
-        $inferrer = new PtableInferrer($inferrable, $list->dc);
+        $inferrer = $this->getPtableInferrer($list);
 
         if ($ptable = $inferrer->getDcaMainPtable())
         {
@@ -183,6 +168,71 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         return $allParents;
     }
 
+    public function processRuntimeValue(mixed $value, ListSpecification $list, FilterDefinition $filter): array
+    {
+        $values = $this->normalizeFilterValue($value);
+
+        // If no value is selected, and the archives not only apply to form options,
+        //   we filter by all whitelisted archives.
+        $useFullWhitelist = !$values && !$filter->useWhitelistForOptionsOnly;
+
+        if ($useFullWhitelist || $values === true)
+            // Empty option selected -> also filter by all whitelisted archives.
+        {
+            // intrinsic value uses whitelist options
+            return $this->getIntrinsicValue($list, $filter);
+        }
+
+        if (!$values) {
+            return [];
+        }
+
+        $inferrer = $this->getPtableInferrer($list);
+        // todo: limit selection to whitelisted archives
+
+        return $values;
+    }
+
+    /**
+     * @return Model[]|true|null Returns true if the empty option is selected.
+     */
+    protected function normalizeFilterValue(mixed $value): array|true|null
+    {
+        if (!$value) {
+            return null;
+        }
+
+        if (!\is_iterable($value)) {
+            $value = [$value];
+        }
+
+        $arr = [];
+
+        foreach ($value as $v) {
+            if ($v === ChoicesBuilder::EMPTY_CHOICE) {
+                return true;
+            }
+
+            if ($v instanceof Model) {
+                $arr[] = $v;
+            }
+        }
+
+        return $arr;
+    }
+
+    private function getPtableInferrer(ListSpecification $list): PtableInferrer
+    {
+        $cacheKey = $list->hash();
+
+        if (isset($this->_inferrer[$cacheKey])) {
+            return $this->_inferrer[$cacheKey];
+        }
+
+        $inferrable = PtableInferrableFactory::createFromListModelLike($list);
+        return $this->_inferrer[$cacheKey] = new PtableInferrer($inferrable, $list->dc);
+    }
+
     public function getPalette(PaletteConfig $config): ?string
     {
         if (!$filterModel = $config->getFilterModel()) {
@@ -195,12 +245,12 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
 
         if ($inferrer->getDcaMainPtable())
         {
-            $palettes[] = '{archive_legend},whitelistParents,formatLabel';
+            $palettes[] = '{archive_legend},whitelistParents,formatLabel,useWhitelistForOptionsOnly';
         }
         /** @mago-expect lint:no-else-clause This else clause is fine. */
         elseif ($inferrer->isDcaDynamicPtable())
         {
-            $palettes[] = '{archive_legend},groupWhitelistParents';
+            $palettes[] = '{archive_legend},groupWhitelistParents,useWhitelistForOptionsOnly';
         }
 
         if (!$filterModel->intrinsic)

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -20,6 +20,7 @@ use HeimrichHannot\FlareBundle\Filter\FilterInvocation;
 use HeimrichHannot\FlareBundle\Form\ChoicesBuilder;
 use HeimrichHannot\FlareBundle\Form\Factory\ChoicesBuilderFactory;
 use HeimrichHannot\FlareBundle\InferPtable\Factory\PtableInferrableFactory;
+use HeimrichHannot\FlareBundle\InferPtable\PtableInferrableInterface;
 use HeimrichHannot\FlareBundle\InferPtable\PtableInferrer;
 use HeimrichHannot\FlareBundle\Model\FilterModel;
 use HeimrichHannot\FlareBundle\Model\ListModel;
@@ -229,14 +230,18 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
     {
         $filter = $event->filter;
 
-        $filterModel = $filter->getDataSource();
-        if (!$filterModel instanceof FilterModel) {
+        $dataSource = $filter->getDataSource();
+        if (!$dataSource instanceof PtableInferrableInterface) {
             return;
         }
 
-        $inferrer = new PtableInferrer($filterModel, $event->list->dc);
+        $inferrer = new PtableInferrer($dataSource, $event->list->dc);
 
         $choices = $event->choicesBuilder->enable();
+
+        $event->options['required'] = (bool) $filter->isMandatory;
+        $event->options['multiple'] = (bool) $filter->isMultiple;
+        $event->options['expanded'] = (bool) $filter->isExpanded;
 
         if ($filter->hasEmptyOption)
         {
@@ -267,10 +272,6 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
             {
                 $choices->add((string) $parent->id, $parent);
             }
-
-            $event->options['required'] = (bool) $filter->isMandatory;
-            $event->options['multiple'] = (bool) $filter->isMultiple;
-            $event->options['expanded'] = (bool) $filter->isExpanded;
 
             return;
         }
@@ -320,10 +321,6 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         }
 
         $choices->setModelSuffix('(%@name%)');
-
-        $event->options['required'] = (bool) $filter->isMandatory;
-        $event->options['multiple'] = (bool) $filter->isMultiple;
-        $event->options['expanded'] = (bool) $filter->isExpanded;
     }
 
     #[AsFilterCallback(self::TYPE, 'fields.preselect.load')]

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -184,7 +184,7 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
             return $this->getWhitelistedParents($list, $filter);
         }
 
-        if (!$values || !\is_array($values)) {
+        if (!$values) {
             return [];
         }
 
@@ -203,10 +203,20 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         }
 
         \array_walk($allowedParentIds, static fn (array &$ids): array => $ids = \array_flip($ids));
-
+        /**
+         * @var array<string, array<int, int>> $allowedParentIds 2D array mapping table names to parent IDs as keys.
+         *   I.e., flips the nested arrays to be lookup tables for efficient filtering.
+         * @example $allowedParentIds = array{
+         *    'tl_news_archive': [
+         *      5:  0,  // where 5 is the ID of the news archive
+         *      8:  1,  // ID 8
+         *      12: 2,  // ID 12
+         *    ]
+         *  }
+         */
         return \array_values(\array_filter(
             $values,
-            static fn (Model $model): bool => isset($allowedLookup[$model::getTable()][$model->id]),
+            static fn (Model $model): bool => isset($allowedParentIds[$model::getTable()][$model->id]),
         ));
     }
 

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -128,7 +128,25 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         );
     }
 
-    public function getIntrinsicValue(ListSpecification $list, FilterDefinition $filter): array
+    protected function getWhitelistedParentIds(ListSpecification $list, FilterDefinition $filter): ?array
+    {
+        $inferrer = $this->getPtableInferrer($list);
+
+        if ($inferrer->getDcaMainPtable())
+        {
+            return $this->getParentIdsFromWhitelistBlob($filter->whitelistParents);
+        }
+
+        if (!$inferrer->isDcaDynamicPtable())
+            // no valid ptable available
+        {
+            return [];
+        }
+
+        return $this->getParentIdsFromGroupWhitelistBlob($filter->groupWhitelistParents);
+    }
+
+    protected function getWhitelistedParents(ListSpecification $list, FilterDefinition $filter): array
     {
         $inferrer = $this->getPtableInferrer($list);
 
@@ -144,57 +162,56 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
             return [];
         }
 
-        if (!$groupWhitelist = StringUtil::deserialize($filter->groupWhitelistParents, true))
-        {
-            return [];
-        }
+        return $this->getParentsFromGroupWhitelistBlob($filter->groupWhitelistParents);
+    }
 
-        $allParents = [];
-
-        foreach ($groupWhitelist as $group)
-        {
-            $table = $group['tablePtable'] ?? null;
-            $whitelistParents = $group['whitelistParents'] ?? null;
-
-            if (!$table || !$whitelistParents) {
-                continue;
-            }
-
-            $parents = $this->getParentsFromWhitelistBlob($table, $whitelistParents)?->getModels() ?? [];
-
-            \array_push($allParents, ...$parents);
-        }
-
-        return $allParents;
+    public function getIntrinsicValue(ListSpecification $list, FilterDefinition $filter): array
+    {
+        return $this->getWhitelistedParents($list, $filter);
     }
 
     public function processRuntimeValue(mixed $value, ListSpecification $list, FilterDefinition $filter): array
     {
         $values = $this->normalizeFilterValue($value);
 
-        // If no value is selected, and the archives not only apply to form options,
-        //   we filter by all whitelisted archives.
+        // If no value is selected, and the filter applies not only to form options,
+        //   we must filter by all whitelisted archives.
         $useFullWhitelist = !$values && !$filter->useWhitelistForOptionsOnly;
 
         if ($useFullWhitelist || $values === true)
             // Empty option selected -> also filter by all whitelisted archives.
         {
-            // intrinsic value uses whitelist options
-            return $this->getIntrinsicValue($list, $filter);
+            return $this->getWhitelistedParents($list, $filter);
         }
 
-        if (!$values) {
+        if (!$values || !\is_array($values)) {
             return [];
         }
 
-        $inferrer = $this->getPtableInferrer($list);
-        // todo: limit selection to whitelisted archives
+        if (!$allowedParentIds = $this->getWhitelistedParentIds($list, $filter)) {
+            return [];
+        }
 
-        return $values;
+        if (\array_is_list($allowedParentIds))
+        {
+            $allowedLookup = \array_flip($allowedParentIds);
+
+            return \array_values(\array_filter(
+                $values,
+                static fn (Model $model): bool => isset($allowedLookup[$model->id]),
+            ));
+        }
+
+        \array_walk($allowedParentIds, static fn (array &$ids): array => $ids = \array_flip($ids));
+
+        return \array_values(\array_filter(
+            $values,
+            static fn (Model $model): bool => isset($allowedLookup[$model::getTable()][$model->id]),
+        ));
     }
 
     /**
-     * @return Model[]|true|null Returns true if the empty option is selected.
+     * @return Model[]|true|null Returns true if the empty option is selected, null if no value is selected.
      */
     protected function normalizeFilterValue(mixed $value): array|true|null
     {
@@ -441,7 +458,23 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
         return $value;
     }
 
-    public function getParentsFromWhitelistBlob(?string $table, ?string $blob): ?Collection
+    /**
+     * @return int[]|null
+     */
+    protected function getParentIdsFromWhitelistBlob(?string $blob): ?array
+    {
+        if (!$whitelist = StringUtil::deserialize($blob, true)) {
+            return null;
+        }
+
+        if (!$whitelist = \array_unique(\array_filter(\array_map('\intval', $whitelist)))) {
+            return null;
+        }
+
+        return \array_values($whitelist);
+    }
+
+    protected function getParentsFromWhitelistBlob(?string $table, ?string $blob): ?Collection
     {
         if (!$table || !$blob) {
             return null;
@@ -455,15 +488,76 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
             return null;
         }
 
-        if (!$whitelist = StringUtil::deserialize($blob, true)) {
-            return null;
-        }
-
-        if (!$whitelist = \array_unique(\array_filter(\array_map('\intval', $whitelist)))) {
-            return null;
-        }
+        $whitelist = $this->getParentIdsFromWhitelistBlob($blob);
 
         return $parentModelClass::findMultipleByIds($whitelist);
+    }
+
+    /**
+     * @return array<string, int[]> Returns an array mapping table names to parent IDs
+     */
+    protected function getParentIdsFromGroupWhitelistBlob(?string $blob): array
+    {
+        $groupWhitelist = StringUtil::deserialize($blob, true);
+
+        $tableToParentIds = [];
+
+        foreach ($groupWhitelist as $group)
+        {
+            if (!\is_array($group)) {
+                continue;
+            }
+
+            $table = $group['tablePtable'] ?? null;
+            $whitelistParentsBlob = $group['whitelistParents'] ?? null;
+
+            if (!$table || !$whitelistParentsBlob) {
+                continue;
+            }
+
+            if (!$parentIds = $this->getParentIdsFromWhitelistBlob($whitelistParentsBlob)) {
+                continue;
+            }
+
+            $tableToParentIds[$table] ??= [];
+            \array_push($tableToParentIds[$table], ...$parentIds);
+        }
+
+        return $tableToParentIds;
+    }
+
+    /**
+     * @param string|null $blob
+     * @return Model[]
+     */
+    protected function getParentsFromGroupWhitelistBlob(?string $blob): array
+    {
+        $tableToParentIds = $this->getParentIdsFromGroupWhitelistBlob($blob);
+
+        $allParents = [];
+
+        foreach ($tableToParentIds as $table => $parentIds)
+        {
+            if (!$parentModelClass = Model::getClassFromTable($table)) {
+                continue;
+            }
+
+            if (!\class_exists($parentModelClass)) {
+                continue;
+            }
+
+            if (!$parentIds = \array_unique($parentIds)) {
+                continue;
+            }
+
+            if (!$coll = $parentModelClass::findMultipleByIds($parentIds)) {
+                continue;
+            }
+
+            \array_push($allParents, ...$coll->getModels());
+        }
+
+        return \array_values($allParents);
     }
 
     public function hydrateForm(FormInterface $field, ListSpecification $list, FilterDefinition $filter): void

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -63,10 +63,12 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
 
         if ($inferrer->getDcaMainPtable())
         {
-            $pids = \array_map(static fn (Model $model): int => (int) $model->id, $selectedModels);
+            if (!$pids = \array_column($selectedModels, 'id')) {
+                throw new FilterException('No valid parent archive ids extracted.');
+            }
 
-            $qb->where($qb->expr()->in($qb->column('pid'), ':pidIn'))
-                ->setParameter('pidIn', $pids, ArrayParameterType::INTEGER);
+            $qb->where($qb->expr()->in($qb->column('pid'), ':pids'))
+                ->setParameter('pids', $pids, ArrayParameterType::INTEGER);
 
             return;
         }

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -63,10 +63,10 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
 
         if ($inferrer->getDcaMainPtable())
         {
-            $filerValueIds = \array_map(static fn (Model $model): int => (int) $model->id, $selectedModels);
+            $pids = \array_map(static fn (Model $model): int => (int) $model->id, $selectedModels);
 
             $qb->where($qb->expr()->in($qb->column('pid'), ':pidIn'))
-                ->setParameter('pidIn', $filerValueIds, ArrayParameterType::INTEGER);
+                ->setParameter('pidIn', $pids, ArrayParameterType::INTEGER);
 
             return;
         }

--- a/src/FilterElement/ArchiveElement.php
+++ b/src/FilterElement/ArchiveElement.php
@@ -549,7 +549,7 @@ class ArchiveElement extends AbstractFilterElement implements HydrateFormContrac
             \array_push($allParents, ...$coll->getModels());
         }
 
-        return \array_values($allParents);
+        return $allParents;
     }
 
     public function hydrateForm(FormInterface $field, ListSpecification $list, FilterDefinition $filter): void

--- a/src/FilterElement/DcaSelectFieldElement.php
+++ b/src/FilterElement/DcaSelectFieldElement.php
@@ -10,6 +10,7 @@ use Contao\StringUtil;
 use Contao\System;
 use HeimrichHannot\FlareBundle\Contract\Config\PaletteConfig;
 use HeimrichHannot\FlareBundle\Contract\FilterElement\HydrateFormContract;
+use HeimrichHannot\FlareBundle\Contract\FilterElement\IntrinsicValueContract;
 use HeimrichHannot\FlareBundle\DependencyInjection\Attribute\AsFilterCallback;
 use HeimrichHannot\FlareBundle\DependencyInjection\Attribute\AsFilterElement;
 use HeimrichHannot\FlareBundle\Event\FilterElementFormTypeOptionsEvent;
@@ -27,7 +28,7 @@ use Symfony\Component\Form\FormInterface;
     type: self::TYPE,
     formType: ChoiceType::class,
 )]
-class DcaSelectFieldElement extends AbstractFilterElement implements HydrateFormContract
+class DcaSelectFieldElement extends AbstractFilterElement implements HydrateFormContract, IntrinsicValueContract
 {
     public const TYPE = 'flare_dcaSelectField';
 
@@ -38,40 +39,19 @@ class DcaSelectFieldElement extends AbstractFilterElement implements HydrateForm
     {
         $options = $this->getOptions($inv->list, $inv->filter) ?? [];
 
-        /** @todo (@ericges): Refactor logic to use IntrinsicValueContract and RuntimeValueContract */
-
-        if ($inv->filter->isIntrinsic())
-        {
-            if (!$preselect = $this->getPreselectValue($inv->filter))
-            {
-                return;
-            }
-
-            if (!$selected = $options[$preselect] ?? null)
-            {
-                $qb->abort();
-            }
-        }
-
-        if (!$selected ??= $inv->getValue())
-        {
+        if (!$selected = $inv->getValue()) {
             return;
         }
 
-        $selected = \array_values((array) $selected);
-
-        if (!\count($selected))
-        {
+        if (!$selected = \array_values((array) $selected)) {
             return;
         }
 
-        if (!$targetField = $inv->filter->fieldGeneric)
-        {
+        if (!$options) {
             $qb->abort();
         }
 
-        if (!$options)
-        {
+        if (!$targetField = $inv->filter->fieldGeneric) {
             $qb->abort();
         }
 
@@ -119,7 +99,7 @@ class DcaSelectFieldElement extends AbstractFilterElement implements HydrateForm
         }
 
         if (!\count($validOptions))
-            // of the submitted values, none is valid
+            // of the submitted values, none are valid
         {
             $qb->abort();
         }
@@ -144,6 +124,11 @@ class DcaSelectFieldElement extends AbstractFilterElement implements HydrateForm
         }
 
         return $palette;
+    }
+
+    public function getIntrinsicValue(ListSpecification $list, FilterDefinition $filter): mixed
+    {
+        return $this->getPreselectValue($filter);
     }
 
     public function getPreselectValue(FilterDefinition $filter): mixed

--- a/src/Form/ChoicesBuilder.php
+++ b/src/Form/ChoicesBuilder.php
@@ -13,7 +13,18 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ChoicesBuilder
 {
+    /**
+     * @api This is the 'choice' property of the empty option. Use as a placholder for a empty choice option.
+     */
     public const EMPTY_CHOICE = '__flare_empty__';
+    /**
+     * @api Use when no choice value shall be submitted when the empty option is selected.
+     */
+    public const EMPTY_CHOICE_VALUE_DEFAULT = '';
+    /**
+     * @api Use when a url parameter value is required.
+     */
+    public const EMPTY_CHOICE_VALUE_ALTERNATIVE = '__';
 
     /** @var array<string, Model|LabelableInterface|string> $choices */
     private array $choices = [];
@@ -25,6 +36,7 @@ class ChoicesBuilder
     private string $modelSuffix = '';
     private bool $enabled = false;
     private bool $emptyOption = false;
+    private string $emptyOptionValue = self::EMPTY_CHOICE_VALUE_DEFAULT;
     private LabelableInterface|string|null $emptyOptionLabel = null;
     private ?string $label = null;
     private array $mapTypeLabel = [];
@@ -147,17 +159,19 @@ class ChoicesBuilder
         return $this->emptyOption;
     }
 
-    public function setEmptyOption(LabelableInterface|string|bool|null $value): static
+    public function setEmptyOption(LabelableInterface|string|bool|null $state_or_label, ?string $value = null): static
     {
-        if (\is_bool($value))
+        $this->emptyOptionValue = $value ?? '';
+
+        if (\is_bool($state_or_label))
         {
-            $this->emptyOption = $value;
+            $this->emptyOption = $state_or_label;
 
             return $this;
         }
 
         $this->emptyOption = true;
-        $this->emptyOptionLabel = $value;
+        $this->emptyOptionLabel = $state_or_label;
 
         return $this;
     }
@@ -201,7 +215,7 @@ class ChoicesBuilder
         return function (mixed $choice): string {
             if ($choice === self::EMPTY_CHOICE)
             {
-                return '';
+                return $this->emptyOptionValue;
             }
 
             if (!$alias = \array_search($choice, $this->choices, true))
@@ -218,7 +232,7 @@ class ChoicesBuilder
         return function (mixed $choice, string $key, mixed $value): TranslatableMessage|string {
             if ($key === self::EMPTY_CHOICE)
             {
-                return $this->buildChoiceLabel($this->emptyOptionLabel, '', '');
+                return $this->buildChoiceLabel($this->emptyOptionLabel, '', $this->emptyOptionValue);
             }
 
             return $this->buildChoiceLabel($choice, $key, $value);
@@ -289,7 +303,7 @@ class ChoicesBuilder
         $options = [];
 
         if ($this->emptyOption) {
-            $options[''] = $this->buildChoiceLabel($this->emptyOptionLabel, '', '');
+            $options[''] = $this->buildChoiceLabel($this->emptyOptionLabel, '', $this->emptyOptionValue);
         }
 
         $labelFactory = $this->buildChoiceLabelCallback();

--- a/src/Form/ChoicesBuilder.php
+++ b/src/Form/ChoicesBuilder.php
@@ -11,6 +11,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @mago-expect lint:too-many-properties
+ */
 class ChoicesBuilder
 {
     /**

--- a/src/Form/ChoicesBuilder.php
+++ b/src/Form/ChoicesBuilder.php
@@ -12,6 +12,38 @@ use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
+ * Builds Symfony form choice configurations from Contao Models, {@see LabelableInterface}
+ * instances, or strings.
+ *
+ * Aggregates choices with optional values (and groups ffu), then produces the artifacts a Symfony
+ * ChoiceType field needs: a choices array via {@see buildChoices()}, a value callback via
+ * {@see buildChoiceValueCallback()}, and a label callback via {@see buildChoiceLabelCallback()}.
+ * For Contao-style option arrays, use {@see buildOptions()} instead.
+ *
+ * Labels are resolved against the `flare_form` translation domain. For a given choice, the first
+ * available source wins:
+ *   1. a per-class/per-table label set via {@see setLabelForClass()}, {@see setLabelForTable()},
+ *      or {@see setLabelForModel()};
+ *   2. the global label from {@see setLabel()};
+ *   3. a default from the `huh_flare.format_label_defaults` parameter, keyed by class or table;
+ *   4. the model's id (Model instances only) or a dash.
+ *
+ * String choices are translated directly. Null choices resolve to the `empty_option.ndash` key.
+ *
+ * Label translations receive the placeholders `%@choice%`, `%@key%`, `%@value%`, `%@type%`, and
+ * `%@class%`. Model choices additionally receive `%@table%`, `%@name%` (the translated
+ * `table.<table>` key), and one placeholder per row field as `%<field>%`. Choices implementing
+ * {@see LabelableInterface} may contribute further parameters via
+ * {@see LabelableInterface::getLabelParameters()}.
+ *
+ * An optional empty option is enabled via {@see setEmptyOption()}. It is rendered under the
+ * sentinel key {@see self::EMPTY_CHOICE} in {@see buildChoices()} (and under an empty-string key
+ * in {@see buildOptions()}), with its submitted value controlled by {@see setEmptyOptionValue()}.
+ * Use {@see self::EMPTY_CHOICE_VALUE_DEFAULT} for no value or
+ * {@see self::EMPTY_CHOICE_VALUE_ALTERNATIVE} when a non-empty URL parameter value is required.
+ *
+ * Group support ({@see addGroup()}, {@see removeGroup()}) is reserved and not yet implemented.
+ *
  * @mago-expect lint:too-many-properties
  */
 class ChoicesBuilder
@@ -49,6 +81,7 @@ class ChoicesBuilder
         private readonly ParameterBagInterface $parameterBag,
     ) {}
 
+    /** @api */
     public function setLabelForTable(?string $label, string $table): self
     {
         if (!$class = Model::getClassFromTable($table)) {
@@ -60,6 +93,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function setLabelForModel(?string $label, Model $model): self
     {
         $this->mapTypeLabel[$model::class] = $label;
@@ -67,6 +101,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function setLabelForClass(?string $label, string $class): self
     {
         if (!$class) {
@@ -86,6 +121,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function setLabel(?string $label): self
     {
         $this->label = $label;
@@ -93,11 +129,13 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function getChoice(string $key): Model|LabelableInterface|string|null
     {
         return $this->choices[$key] ?? null;
     }
 
+    /** @api */
     public function add(
         string                          $alias,
         Model|LabelableInterface|string $choice,
@@ -117,6 +155,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @interal Functionality not yet implemented. */
     public function addGroup(string $key, string $label): static
     {
         $this->groups[$key] = $label;
@@ -124,6 +163,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @interal Functionality not yet implemented. */
     public function removeGroup(string $key): static
     {
         unset($this->groups[$key]);
@@ -131,6 +171,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function setEnabled(bool $enabled): static
     {
         $this->enabled = $enabled;
@@ -138,11 +179,13 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function isEnabled(): bool
     {
         return $this->enabled;
     }
 
+    /** @api */
     public function enable(): static
     {
         $this->enabled = true;
@@ -150,6 +193,7 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function disable(): static
     {
         $this->enabled = false;
@@ -162,9 +206,12 @@ class ChoicesBuilder
         return $this->emptyOption;
     }
 
+    /** @api */
     public function setEmptyOption(LabelableInterface|string|bool|null $state_or_label, ?string $value = null): static
     {
-        $this->emptyOptionValue = $value ?? '';
+        if (!\is_null($value)) {
+            $this->emptyOptionValue = $value;
+        }
 
         if (\is_bool($state_or_label))
         {
@@ -179,6 +226,15 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
+    public function setEmptyOptionValue(string $value): static
+    {
+        $this->emptyOptionValue = $value;
+
+        return $this;
+    }
+
+    /** @api */
     public function setModelSuffix(string $modelSuffix): static
     {
         $this->modelSuffix = $modelSuffix;
@@ -186,16 +242,19 @@ class ChoicesBuilder
         return $this;
     }
 
+    /** @api */
     public function getModelSuffix(): string
     {
         return $this->modelSuffix;
     }
 
+    /** @api */
     public function count(): int
     {
         return \count($this->choices);
     }
 
+    /** @api */
     public function buildChoices(): array
     {
         $choices = [];
@@ -213,6 +272,7 @@ class ChoicesBuilder
         return $choices;
     }
 
+    /** @api */
     public function buildChoiceValueCallback(): callable
     {
         return function (mixed $choice): string {
@@ -230,6 +290,7 @@ class ChoicesBuilder
         };
     }
 
+    /** @api */
     public function buildChoiceLabelCallback(): callable
     {
         return function (mixed $choice, string $key, mixed $value): TranslatableMessage|string {
@@ -242,6 +303,7 @@ class ChoicesBuilder
         };
     }
 
+    /** @api */
     public function buildChoiceLabel(mixed $choice, string $key, mixed $value): TranslatableMessage|string
     {
         $params = [
@@ -300,6 +362,8 @@ class ChoicesBuilder
 
     /**
      * Builds the Contao-compatible options array for a form field.
+     *
+     * @api
      */
     public function buildOptions(): array
     {
@@ -322,6 +386,7 @@ class ChoicesBuilder
 
     /**
      * @param class-string $type
+     * @internal
      */
     private function tryGetTypeLabel(string $type): ?string
     {
@@ -330,6 +395,7 @@ class ChoicesBuilder
 
     /**
      * @param class-string $type
+     * @internal
      */
     private function tryGetDefaultTypeLabel(string $type): ?string
     {
@@ -344,6 +410,7 @@ class ChoicesBuilder
 
     /**
      * @param class-string $class
+     * @internal
      */
     private function tryGetTableFromClass(string $class): ?string
     {

--- a/src/Form/ChoicesBuilder.php
+++ b/src/Form/ChoicesBuilder.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ChoicesBuilder
 {
     /**
-     * @api This is the 'choice' property of the empty option. Use as a placholder for a empty choice option.
+     * @api This is the 'choice' property of the empty option. Use as a placeholder for a empty choice option.
      */
     public const EMPTY_CHOICE = '__flare_empty__';
     /**

--- a/src/Model/DocumentsFilterModelTrait.php
+++ b/src/Model/DocumentsFilterModelTrait.php
@@ -25,6 +25,7 @@ namespace HeimrichHannot\FlareBundle\Model;
  * @property bool   $useStart
  * @property bool   $useStop
  * @property bool   $invertPublished
+ * @property bool   $useWhitelistForOptionsOnly
  * @property string $formatLabel
  * @property string $formatLabelCustom
  * @property string $formatEmptyOption

--- a/src/Specification/ListSpecification.php
+++ b/src/Specification/ListSpecification.php
@@ -49,6 +49,7 @@ class ListSpecification
     {
         return \sha1(\serialize([
             $this->type,
+            $this->dc,
             $this->filters->hash(),
             'model' => $this->dataSource ? [
                 $this->dataSource->getListIdentifier(),


### PR DESCRIPTION
This pull request introduces a new option to control how whitelists are applied to archive filters, refactors and clarifies the archive filter logic, and improves form hydration and value normalization. The main goal is to allow the whitelist to be applied only to form options (rather than always filtering results), and to make the code more robust and maintainable.

**Key changes include:**

### New Feature: Whitelist Application Option

* Added a new boolean field `useWhitelistForOptionsOnly` to the filter configuration (`tl_flare_filter.php`), allowing the whitelist to restrict only the form options, not the filtered results. This is surfaced in the backend and translated in the German language file. [[1]](diffhunk://#diff-c02eb2d89caabca956192e6f43bfed580837627bce8c6c842a512e3b1a72183cR230-R242) [[2]](diffhunk://#diff-a1a9eb49b0b95193fc87a9c096abbafd4f758806b27a5c02943377a14dd4a626R61)

### Archive Filter Logic Refactoring

* Refactored `ArchiveElement` to support the new whitelist option, improving the logic for filtering by whitelisted parents and handling empty selections. The filtering now distinguishes between intrinsic and runtime values, and uses helper methods for clarity and reuse. [[1]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046L48-R69) [[2]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046L113-R123) [[3]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046L161-R238)
* Added helper methods to parse and retrieve whitelisted parent IDs and models from configuration blobs, supporting both single and grouped whitelist configurations.

### Form Handling and Value Normalization

* Improved normalization of filter values, including handling the empty option and converting values to arrays of models.
* Enhanced form hydration in `InteractiveProjector` to ensure form data is set correctly, and updated mapping of form data to filter keys to use `getData()` instead of `getViewData()`. [[1]](diffhunk://#diff-398a3e6d2849a4d8cf9eb2528530ea8d4e41ea09f8959af62597aa7d08f72828R136) [[2]](diffhunk://#diff-398a3e6d2849a4d8cf9eb2528530ea8d4e41ea09f8959af62597aa7d08f72828R176-R180) [[3]](diffhunk://#diff-398a3e6d2849a4d8cf9eb2528530ea8d4e41ea09f8959af62597aa7d08f72828L190-R195)

### Codebase and Interface Improvements

* Updated the `RuntimeValueContract` interface docblock for clarity.
* Minor code clean-up and improved dependency handling in `ArchiveElement` and related classes. [[1]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046R23) [[2]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046R39-R40)

### Form Option Handling

* Adjusted form type options in `ArchiveElement` to correctly set `required`, `multiple`, and `expanded` options, and to handle empty option values appropriately for different input types. [[1]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046L232-R311) [[2]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046L271-L274) [[3]](diffhunk://#diff-5b2082625efd2dbeb967c755e8031753f19819f6a93c43dcb30824ae89a6c046L323-L326)

These changes collectively improve the flexibility and reliability of archive filtering, especially in complex scenarios involving whitelists and dynamic parent tables.

Fixes #14.