### PR TITLE
Refactor `PtableInferrer`, introduce `FormDataContract`, and enhance language files

### DIFF
--- a/contao/languages/en/tl_flare_filter.php
+++ b/contao/languages/en/tl_flare_filter.php
@@ -58,6 +58,7 @@ $lang['groupWhitelistParents'] = ['Define allowed parent archives', 'Please choo
 $lang['formatLabel'] = ['Formatting', 'Please select a formatting option for display.'];
 $lang['formatLabel_custom'] = 'Custom formatting';
 $lang['formatLabelCustom'] = ['Custom formatting', 'Please enter a formatting rule for display.'];
+$lang['useWhitelistForOptionsOnly'] = ['Apply whitelist to form options only', 'Active: the whitelist only restricts the archives shown in the filter. Without a selection in the form, items from other archives are also displayed.'];
 ###< archive_legend ###
 
 ###> form_legend ###
@@ -71,6 +72,7 @@ $lang['formatEmptyOption'] = ['Display empty option as', 'Please select a format
 $lang['formatEmptyOption_custom'] = 'Custom formatting';
 $lang['formatEmptyOptionCustom'] = ['Empty option formatting', 'Please enter a text or label format for the empty option.'];
 $lang['preselect'] = ['Preselection', 'Specify which values should be preselected.'];
+$lang['prefill'] = ['Prefill', 'Specify the text to prefill the field content with.'];
 $lang['placeholder'] = ['Placeholder', 'Please enter a placeholder text.'];
 $lang['label'] = ['Label', 'Please enter a label for the field.'];
 ###< form_legend ###

--- a/contao/languages/en/tl_flare_list.php
+++ b/contao/languages/en/tl_flare_list.php
@@ -55,6 +55,10 @@ $lang['whichPtable_options'] = [
 ];
 ###< parent_legend ###
 
+###> advanced_legend ###
+$lang['advanced_legend'] = 'Advanced Settings';
+###< advanced_legend ###
+
 ###> comments_legend ###
 $lang['comments_legend'] = 'Comment Settings';
 $lang['comments_enabled'] = ['Enable Comments', 'Enable the comment function for entries of this list.'];

--- a/src/Contract/FilterElement/FormDataContract.php
+++ b/src/Contract/FilterElement/FormDataContract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace HeimrichHannot\FlareBundle\Contract\FilterElement;
 
 use Symfony\Component\Form\FormInterface;

--- a/src/Contract/FilterElement/FormDataContract.php
+++ b/src/Contract/FilterElement/FormDataContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace HeimrichHannot\FlareBundle\Contract\FilterElement;
+
+use Symfony\Component\Form\FormInterface;
+
+interface FormDataContract
+{
+    public function extractFormData(FormInterface $form): mixed;
+}

--- a/src/DataContainer/ListContainer.php
+++ b/src/DataContainer/ListContainer.php
@@ -144,7 +144,7 @@ class ListContainer implements FlareCallbackContainerInterface
         }
 
         // if no data container is set, use the default data container of the list type
-        $expectedDataContainer ??= $listTypeConfig->getAttributes()['dc'] ?? '';
+        $expectedDataContainer ??= $listTypeConfig->getDataContainer();
 
         if (!$expectedDataContainer) {
             throw new BadRequestHttpException('No data container found for list type ' . $type);

--- a/src/Engine/Projector/InteractiveProjector.php
+++ b/src/Engine/Projector/InteractiveProjector.php
@@ -178,8 +178,8 @@ class InteractiveProjector extends AbstractProjector
             $data[$filterName] = $field->getData();
         }
 
-        // This might not be necessary, but we keep it here for reference.
-        // $form->setData(\array_merge($form->getData() ?? [], $data));
+        // This might not be necessary, but $form->getData() should return all child data as well.
+        $form->setData(\array_merge($form->getData() ?? [], $data));
     }
 
     protected function mapFormDataToFilterKeys(ListSpecification $list, FormInterface $form): array

--- a/src/Engine/Projector/InteractiveProjector.php
+++ b/src/Engine/Projector/InteractiveProjector.php
@@ -22,7 +22,6 @@ use HeimrichHannot\FlareBundle\Paginator\Factory\PaginatorFactory;
 use HeimrichHannot\FlareBundle\Paginator\Paginator;
 use HeimrichHannot\FlareBundle\Reader\Factory\ReaderUrlGeneratorFactory;
 use HeimrichHannot\FlareBundle\Reader\ReaderUrlGeneratorInterface;
-use HeimrichHannot\FlareBundle\Registry\FilterElementRegistry;
 use HeimrichHannot\FlareBundle\Specification\ListSpecification;
 use Symfony\Component\Form\Exception\OutOfBoundsException;
 use Symfony\Component\Form\FormInterface;
@@ -35,7 +34,6 @@ class InteractiveProjector extends AbstractProjector
     public function __construct(
         private readonly AggregationContextFactory $aggregationConfigFactory,
         private readonly FilterFormFactory         $filterFormFactory,
-        private readonly FilterElementRegistry     $filterElementRegistry,
         private readonly LoaderFactory             $loaderFactory,
         private readonly PaginatorFactory          $paginatorFactory,
         private readonly ReaderUrlGeneratorFactory $readerUrlGeneratorFactory,
@@ -188,6 +186,8 @@ class InteractiveProjector extends AbstractProjector
     {
         $values = [];
 
+        $filterElementRegistry = $this->getFilterElementRegistry();
+
         foreach ($list->getFilters()->all() as $key => $definition)
         {
             $alias = $definition->getAlias();
@@ -201,7 +201,7 @@ class InteractiveProjector extends AbstractProjector
             }
 
             $field = $form->get($alias);
-            $filterElement = $this->filterElementRegistry->get($definition->getType())?->getService();
+            $filterElement = $filterElementRegistry->get($definition->getType())?->getService();
 
             $values[$key] = $filterElement instanceof FormDataContract
                 ? $filterElement->extractFormData($field)

--- a/src/Engine/Projector/InteractiveProjector.php
+++ b/src/Engine/Projector/InteractiveProjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace HeimrichHannot\FlareBundle\Engine\Projector;
 
+use HeimrichHannot\FlareBundle\Contract\FilterElement\FormDataContract;
 use HeimrichHannot\FlareBundle\Contract\FilterElement\HydrateFormContract;
 use HeimrichHannot\FlareBundle\Engine\Context\ContextInterface;
 use HeimrichHannot\FlareBundle\Engine\Context\Factory\AggregationContextFactory;
@@ -21,6 +22,7 @@ use HeimrichHannot\FlareBundle\Paginator\Factory\PaginatorFactory;
 use HeimrichHannot\FlareBundle\Paginator\Paginator;
 use HeimrichHannot\FlareBundle\Reader\Factory\ReaderUrlGeneratorFactory;
 use HeimrichHannot\FlareBundle\Reader\ReaderUrlGeneratorInterface;
+use HeimrichHannot\FlareBundle\Registry\FilterElementRegistry;
 use HeimrichHannot\FlareBundle\Specification\ListSpecification;
 use Symfony\Component\Form\Exception\OutOfBoundsException;
 use Symfony\Component\Form\FormInterface;
@@ -33,6 +35,7 @@ class InteractiveProjector extends AbstractProjector
     public function __construct(
         private readonly AggregationContextFactory $aggregationConfigFactory,
         private readonly FilterFormFactory         $filterFormFactory,
+        private readonly FilterElementRegistry     $filterElementRegistry,
         private readonly LoaderFactory             $loaderFactory,
         private readonly PaginatorFactory          $paginatorFactory,
         private readonly ReaderUrlGeneratorFactory $readerUrlGeneratorFactory,
@@ -177,23 +180,32 @@ class InteractiveProjector extends AbstractProjector
             $data[$filterName] = $field->getData();
         }
 
-        $form->setData(\array_merge($form->getData() ?? [], $data));
+        // This might not be necessary, but we keep it here for reference.
+        // $form->setData(\array_merge($form->getData() ?? [], $data));
     }
 
     protected function mapFormDataToFilterKeys(ListSpecification $list, FormInterface $form): array
     {
-        if (!$formData = $form->getData()) {
-            return [];
-        }
-
         $values = [];
 
         foreach ($list->getFilters()->all() as $key => $definition)
         {
-            $formName = $definition->getAlias();
-            if ($formName && \array_key_exists($formName, $formData)) {
-                $values[$key] = $form->get($formName)->getData();
+            $alias = $definition->getAlias();
+
+            if (\is_null($alias)) {
+                continue;
             }
+
+            if (!$form->has($alias)) {
+                continue;
+            }
+
+            $field = $form->get($alias);
+            $filterElement = $this->filterElementRegistry->get($definition->getType())?->getService();
+
+            $values[$key] = $filterElement instanceof FormDataContract
+                ? $filterElement->extractFormData($field)
+                : $field->getData();
         }
 
         return $values;

--- a/src/EventListener/DataContainer/FlareFilter/WhichPtableCheckCallback.php
+++ b/src/EventListener/DataContainer/FlareFilter/WhichPtableCheckCallback.php
@@ -35,8 +35,6 @@ readonly class WhichPtableCheckCallback
         {
             $inferrer = new PtableInferrer($filterModel, $listModel->dc);
 
-            $inferrer->infer();
-
             if (!$inferrer->isAutoInferable())
             {
                 $filterModel->whichPtable_disableAutoOption();

--- a/src/EventListener/DataContainer/FlareList/WhichPtableCheckCallback.php
+++ b/src/EventListener/DataContainer/FlareList/WhichPtableCheckCallback.php
@@ -35,8 +35,6 @@ readonly class WhichPtableCheckCallback
         {
             $inferrer = new PtableInferrer($listModel, $listModel->dc);
 
-            $inferrer->infer();
-
             if (!$inferrer->isAutoInferable())
             {
                 $listModel->whichPtable_disableAutoOption();

--- a/src/FilterElement/AbstractFilterElement.php
+++ b/src/FilterElement/AbstractFilterElement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HeimrichHannot\FlareBundle\FilterElement;
 
 use HeimrichHannot\FlareBundle\Contract\Config\PaletteConfig;
+use HeimrichHannot\FlareBundle\Contract\FilterElement\FormDataContract;
 use HeimrichHannot\FlareBundle\Contract\FilterElement\FormTypeOptionsContract;
 use HeimrichHannot\FlareBundle\Contract\FilterElement\RuntimeValueContract;
 use HeimrichHannot\FlareBundle\Contract\IsSupportedContract;
@@ -16,6 +17,7 @@ use HeimrichHannot\FlareBundle\Filter\FilterInvokerInterface;
 use HeimrichHannot\FlareBundle\Query\FilterQueryBuilder;
 use HeimrichHannot\FlareBundle\Specification\FilterDefinition;
 use HeimrichHannot\FlareBundle\Specification\ListSpecification;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -27,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *  }
  */
 abstract class AbstractFilterElement implements FilterInvokerInterface, OptionsInterface,
-    FormTypeOptionsContract, IsSupportedContract, PaletteContract, RuntimeValueContract
+    FormDataContract, FormTypeOptionsContract, IsSupportedContract, PaletteContract, RuntimeValueContract
 {
     /**
      * @var FormOptionsShape|string[] Defines which filter-model fields to use for auto-generating form type options.
@@ -52,7 +54,8 @@ abstract class AbstractFilterElement implements FilterInvokerInterface, OptionsI
      * Creates default form type options based on default filter model fields and the given config.
      *
      * @param FilterDefinition $filter The filter definition.
-     * @param array<string, mixed>|array<int, string>|array<int|string, mixed>|FormOptionsShape|list<key-of<FormOptionsShape>> $config The config to use.
+     * @param array<string, mixed>|array<int, string>|array<int|string,
+     *     mixed>|FormOptionsShape|list<key-of<FormOptionsShape>> $config The config to use.
      *
      * @return array
      *
@@ -100,6 +103,11 @@ abstract class AbstractFilterElement implements FilterInvokerInterface, OptionsI
     }
 
     public function handleFormTypeOptions(FilterElementFormTypeOptionsEvent $event): void {}
+
+    public function extractFormData(FormInterface $form): mixed
+    {
+        return $form->getData();
+    }
 
     public function isSupported(): bool
     {

--- a/src/FilterElement/BelongsToRelationElement.php
+++ b/src/FilterElement/BelongsToRelationElement.php
@@ -41,7 +41,7 @@ class BelongsToRelationElement extends AbstractFilterElement
 
         try
         {
-            $ptable = $inferrer->explicit();
+            $ptable = $inferrer->getInferredPtable();
             $fieldDynamicPtable = $inferrer->tryGetDynamicPtableField();
         }
         catch (InferenceException)
@@ -166,7 +166,7 @@ class BelongsToRelationElement extends AbstractFilterElement
 
         try
         {
-            $ptable = $inferrer->explicit(true);
+            $ptable = $inferrer->getInferredPtable();
 
             Message::addInfo(match (true) {
                 $inferrer->isAutoInferable() && $ptable => $this->trans->trans('infer_ptable.auto', [

--- a/src/FilterElement/DcaSelectFieldElement.php
+++ b/src/FilterElement/DcaSelectFieldElement.php
@@ -138,6 +138,11 @@ class DcaSelectFieldElement extends AbstractFilterElement implements HydrateForm
             : $filter->preselect;
     }
 
+    public function extractFormData(FormInterface $form): mixed
+    {
+        return $form->getViewData();
+    }
+
     public function hydrateForm(FormInterface $field, ListSpecification $list, FilterDefinition $filter): void
     {
         if ($field->isSubmitted()) {

--- a/src/InferPtable/PtableInferrer.php
+++ b/src/InferPtable/PtableInferrer.php
@@ -23,6 +23,7 @@ final class PtableInferrer
     private bool $autoDynamicPtable = false;
     private bool $inferred = false;
     private ?string $inferredPtable;
+    private array $entityDca;
 
     public function __construct(
         private readonly PtableInferrableInterface $inferrable,
@@ -66,20 +67,44 @@ final class PtableInferrer
         return $this->inferredPtable ?? null;
     }
 
+    /**
+     * @deprecated Use {@see getEntityDca()} instead. Removal pending for v0.2.
+     */
     public function getDCA(): ?array
     {
+        return $this->getEntityDca();
+    }
+
+    /**
+     * @throws never {@see InferenceException}
+     * @noinspection PhpDocMissingThrowsInspection,PhpUnhandledExceptionInspection
+     */
+    public function getEntityDca(): array
+    {
+        if (isset($this->entityDca)) {
+            return $this->entityDca;
+        }
+
         if (!$this->entityTable) {
-            return null;
+            throw new InferenceException('No entity table set');
         }
 
         Controller::loadDataContainer($this->entityTable);
 
-        return $GLOBALS['TL_DCA'][$this->entityTable] ?? null;
+        if (!$dca = $GLOBALS['TL_DCA'][$this->entityTable] ?? null) {
+            throw new InferenceException(\sprintf('No data container array found for "%s"', $this->entityTable));
+        }
+
+        if (!\is_array($dca)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid data container array for "%s"', $this->entityTable));
+        }
+
+        return $this->entityDca = $dca;
     }
 
     public function getDcaMainPtable(): ?string
     {
-        if (!$entityDca = $this->getDCA()) {
+        if (!$entityDca = $this->getEntityDca()) {
             return null;
         }
 
@@ -94,7 +119,7 @@ final class PtableInferrer
 
     public function isDcaDynamicPtable(): bool
     {
-        if (!$entityDca = $this->getDCA()) {
+        if (!$entityDca = $this->getEntityDca()) {
             return false;
         }
 
@@ -113,9 +138,7 @@ final class PtableInferrer
             return $this->inferredPtable ?? null;
         }
 
-        if (!$entityDca = $this->getDCA()) {
-            throw new InferenceException('No data container array found for ' . $this->entityTable);
-        }
+        $entityDca = $this->getEntityDca();
 
         $this->inferred = true;
         $this->inferredPtable = null;
@@ -169,7 +192,7 @@ final class PtableInferrer
     {
         $this->inferredPtable = null;
         $this->autoInferable = false;
-        $this->autoDynamicPtable = (bool) ($entityDca['config']['dynamicPtable'] ?? false);
+        $this->autoDynamicPtable = (bool) ($this->getEntityDca()['config']['dynamicPtable'] ?? false);
     }
 
     /**

--- a/src/InferPtable/PtableInferrer.php
+++ b/src/InferPtable/PtableInferrer.php
@@ -103,7 +103,8 @@ final class PtableInferrer
 
     /**
      * @throws InferenceException
-     * @deprecated Use {@see self::getInferredPtable()} instead. Return type will change to void. Visibility will change to private.
+     * @deprecated Use {@see self::getInferredPtable()} instead. Return type will change to void. Visibility will
+     *     change to private.
      */
     #[\ReturnTypeWillChange]
     public function infer(): ?string
@@ -112,7 +113,12 @@ final class PtableInferrer
             return $this->inferredPtable ?? null;
         }
 
+        if (!$entityDca = $this->getDCA()) {
+            throw new InferenceException('No data container array found for ' . $this->entityTable);
+        }
+
         $this->inferred = true;
+        $this->inferredPtable = null;
         $this->autoInferable = true;
         $this->autoDynamicPtable = false;
 
@@ -125,9 +131,14 @@ final class PtableInferrer
             return $this->inferredPtable;
         }
 
-        if (!$entityDca = $this->getDCA()) {
-            throw new InferenceException('No data container array found for ' . $this->entityTable);
+        if ($whichPtable === self::WHICH_PTABLE_DYNAMIC)
+        {
+            $this->setupDynamicPtable();
+
+            return $this->inferredPtable;
         }
+
+        // $whichPtable === self::WHICH_PTABLE_AUTO
 
         $fieldPid = $this->inferrable->getInferFieldPid() ?: 'pid';
 
@@ -149,11 +160,16 @@ final class PtableInferrer
             return $this->inferredPtable;
         }
 
+        $this->setupDynamicPtable();
+
+        return $this->inferredPtable;
+    }
+
+    private function setupDynamicPtable(): void
+    {
         $this->inferredPtable = null;
         $this->autoInferable = false;
         $this->autoDynamicPtable = (bool) ($entityDca['config']['dynamicPtable'] ?? false);
-
-        return $this->inferredPtable;
     }
 
     /**

--- a/src/InferPtable/PtableInferrer.php
+++ b/src/InferPtable/PtableInferrer.php
@@ -75,13 +75,13 @@ class PtableInferrer
         return null;
     }
 
-    public function isDcaDynamicPtable(): ?string
+    public function isDcaDynamicPtable(): bool
     {
         if (!$entityDca = $this->getDCA()) {
-            return null;
+            return false;
         }
 
-        return $entityDca['config']['dynamicPtable'] ?? null;
+        return $entityDca['config']['dynamicPtable'] ?? false;
     }
 
     /**

--- a/src/InferPtable/PtableInferrer.php
+++ b/src/InferPtable/PtableInferrer.php
@@ -7,7 +7,7 @@ namespace HeimrichHannot\FlareBundle\InferPtable;
 use Contao\Controller;
 use HeimrichHannot\FlareBundle\Exception\InferenceException;
 
-class PtableInferrer
+final class PtableInferrer
 {
     public const WHICH_PTABLE_AUTO = 'auto';
     public const WHICH_PTABLE_STATIC = 'static';
@@ -19,14 +19,14 @@ class PtableInferrer
         self::WHICH_PTABLE_DYNAMIC,
     ];
 
-    protected bool $autoInferable = true;
-    protected bool $autoDynamicPtable = false;
-    protected bool $inferred = false;
-    protected ?string $inferredPtable;
+    private bool $autoInferable = true;
+    private bool $autoDynamicPtable = false;
+    private bool $inferred = false;
+    private ?string $inferredPtable;
 
     public function __construct(
-        protected PtableInferrableInterface $inferrable,
-        protected string                    $entityTable,
+        private readonly PtableInferrableInterface $inferrable,
+        private readonly string                    $entityTable,
     ) {}
 
     public function getInferrable(): PtableInferrableInterface
@@ -34,19 +34,36 @@ class PtableInferrer
         return $this->inferrable;
     }
 
+    public function getEntityTable(): string
+    {
+        return $this->entityTable;
+    }
+
     public function isAutoInferable(): bool
     {
+        if (!$this->inferred) {
+            $this->infer();
+        }
+
         return $this->autoInferable;
     }
 
     public function isAutoDynamicPtable(): bool
     {
+        if (!$this->inferred) {
+            $this->infer();
+        }
+
         return $this->autoDynamicPtable;
     }
 
-    public function getEntityTable(): string
+    public function getInferredPtable(): ?string
     {
-        return $this->entityTable;
+        if (!$this->inferred) {
+            $this->infer();
+        }
+
+        return $this->inferredPtable ?? null;
     }
 
     public function getDCA(): ?array
@@ -86,18 +103,31 @@ class PtableInferrer
 
     /**
      * @throws InferenceException
+     * @deprecated Use {@see self::getInferredPtable()} instead. Return type will change to void. Visibility will change to private.
      */
+    #[\ReturnTypeWillChange]
     public function infer(): ?string
     {
         if ($this->inferred) {
             return $this->inferredPtable ?? null;
         }
 
+        $this->inferred = true;
+        $this->autoInferable = true;
+        $this->autoDynamicPtable = false;
+
+        $whichPtable = $this->inferrable->getInferWhichPtable();
+
+        if ($whichPtable === self::WHICH_PTABLE_STATIC)
+        {
+            $this->inferredPtable = $this->inferrable->getInferTablePtable();
+
+            return $this->inferredPtable;
+        }
+
         if (!$entityDca = $this->getDCA()) {
             throw new InferenceException('No data container array found for ' . $this->entityTable);
         }
-
-        $this->inferred = true;
 
         $fieldPid = $this->inferrable->getInferFieldPid() ?: 'pid';
 
@@ -106,8 +136,6 @@ class PtableInferrer
             //   => default contao behavior with the parent id field being "pid"
         {
             $this->inferredPtable = $ptable;
-            $this->autoInferable = true;
-            $this->autoDynamicPtable = false;
 
             return $this->inferredPtable;
         }
@@ -117,8 +145,6 @@ class PtableInferrer
         {
             [$ptable, $field] = \explode('.', $foreignKey);
             $this->inferredPtable = $ptable;
-            $this->autoInferable = true;
-            $this->autoDynamicPtable = false;
 
             return $this->inferredPtable;
         }
@@ -134,18 +160,11 @@ class PtableInferrer
      * Considers all possible cases and returns the inferred or user-defined ptable as explicitly as possible.
      *
      * @throws InferenceException
+     * @deprecated Use {@see self::getInferredPtable()} instead. Removal pending for v0.2.
      */
     public function explicit(bool $alwaysInfer = false): ?string
     {
-        if ($alwaysInfer) {
-            $this->infer();
-        }
-
-        return match ($this->inferrable->getInferWhichPtable()) {
-            self::WHICH_PTABLE_DYNAMIC => null,
-            self::WHICH_PTABLE_STATIC => $this->inferrable->getInferTablePtable(),
-            default => $this->infer(),
-        };
+        return $this->getInferredPtable();
     }
 
     public function getPidField(): string
@@ -156,7 +175,7 @@ class PtableInferrer
     /**
      * @throws InferenceException
      */
-    public function tryGetDynamicPtableField(): string|null
+    public function tryGetDynamicPtableField(): ?string
     {
         if ($this->inferrable->getInferWhichPtable() === self::WHICH_PTABLE_STATIC)
         {
@@ -168,9 +187,7 @@ class PtableInferrer
             return $this->inferrable->getInferFieldPtable() ?: 'ptable';
         }
 
-        $this->infer();
-
-        if ($this->autoDynamicPtable)
+        if ($this->isAutoDynamicPtable())
         {
             return 'ptable';
         }

--- a/src/InferPtable/PtableInferrer.php
+++ b/src/InferPtable/PtableInferrer.php
@@ -70,7 +70,7 @@ final class PtableInferrer
     /**
      * @deprecated Use {@see getEntityDca()} instead. Removal pending for v0.2.
      */
-    public function getDCA(): ?array
+    public function getDCA(): array
     {
         return $this->getEntityDca();
     }

--- a/src/ListType/GenericDataContainerListType.php
+++ b/src/ListType/GenericDataContainerListType.php
@@ -65,7 +65,7 @@ class GenericDataContainerListType extends AbstractListType implements DataConta
 
         try
         {
-            $ptable = $inferrer->explicit(true);
+            $ptable = $inferrer->getInferredPtable();
 
             Message::addInfo(match (true) {
                 $inferrer->isAutoInferable() && $ptable => $this->trans->trans('infer_ptable.auto', [

--- a/src/Registry/ListTypeRegistry.php
+++ b/src/Registry/ListTypeRegistry.php
@@ -18,4 +18,15 @@ class ListTypeRegistry extends AbstractServiceDescriptorRegistry
     {
         return ListTypeDescriptor::class;
     }
+
+    public function get(?string $alias): ?ListTypeDescriptor
+    {
+        $descriptor = parent::get($alias);
+
+        if (!$descriptor instanceof ListTypeDescriptor) {
+            return null;
+        }
+
+        return $descriptor;
+    }
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the codebase, focusing on the filter element system, parent table inference, and language file enhancements. The most significant changes include a refactor of the `PtableInferrer` class for better encapsulation and reliability, introduction of a new contract for extracting form data, and updates to language files for improved clarity and configuration options.

**Core Refactoring and Reliability Improvements:**

* Refactored the `PtableInferrer` class to be `final`, improved encapsulation by making properties private, and centralized inference logic. Added new methods like `getInferredPtable()` and `getEntityDca()`, deprecated old methods, and ensured inference is always performed before returning values. Also, improved error handling and reliability of DCA access. [[1]](diffhunk://#diff-ad5d648650e779ca2665239ddc977861c7fc21d20860ebf783d8b50ddbcbc918L10-R10) [[2]](diffhunk://#diff-ad5d648650e779ca2665239ddc977861c7fc21d20860ebf783d8b50ddbcbc918L22-R107) [[3]](diffhunk://#diff-ad5d648650e779ca2665239ddc977861c7fc21d20860ebf783d8b50ddbcbc918L78-R164) [[4]](diffhunk://#diff-ad5d648650e779ca2665239ddc977861c7fc21d20860ebf783d8b50ddbcbc918L120-R206) [[5]](diffhunk://#diff-ad5d648650e779ca2665239ddc977861c7fc21d20860ebf783d8b50ddbcbc918L159-R217) [[6]](diffhunk://#diff-ad5d648650e779ca2665239ddc977861c7fc21d20860ebf783d8b50ddbcbc918L171-R229)

* Updated all usages of the old `explicit()` method to use the new `getInferredPtable()` method, aligning with the refactored API and deprecation plan. [[1]](diffhunk://#diff-7b3f390fc0e33281d71acfa91da48356061cd58990770e10602169814192c26bL44-R44) [[2]](diffhunk://#diff-7b3f390fc0e33281d71acfa91da48356061cd58990770e10602169814192c26bL169-R169) [[3]](diffhunk://#diff-2c0c25d5a2ae24c73b7a20bd5f7d5aab74ebf82a12957348815eebe7c4fa3d27L68-R68)

**Form Data Extraction and Filter Element System:**

* Introduced a new `FormDataContract` interface for extracting form data from `FormInterface` instances, and implemented it in `AbstractFilterElement` and `DcaSelectFieldElement` for more flexible and type-specific data extraction. [[1]](diffhunk://#diff-bf8ba3cbe5393453462b3cb9247e67fdc8f65f8033bdfed4b6065ad5944a9bbbR1-R12) [[2]](diffhunk://#diff-c503925c55c49fb9eba97c5f642e1e7943ca62cebfd6c5ff24c6d6439ce90fe1R8) [[3]](diffhunk://#diff-c503925c55c49fb9eba97c5f642e1e7943ca62cebfd6c5ff24c6d6439ce90fe1R20) [[4]](diffhunk://#diff-c503925c55c49fb9eba97c5f642e1e7943ca62cebfd6c5ff24c6d6439ce90fe1L30-R32) [[5]](diffhunk://#diff-c503925c55c49fb9eba97c5f642e1e7943ca62cebfd6c5ff24c6d6439ce90fe1R107-R111) [[6]](diffhunk://#diff-ea0d2071f5e2055b2d4919c5da20d0fbbde12c9d83bc9ec04fbfe82434d3aaa1R141-R145)

* Updated the filter element registry and data mapping logic to use the new `FormDataContract` interface, allowing filter elements to control how their form data is extracted.

**Language File and Configuration Enhancements:**

* Added new language labels and configuration options, such as "Apply whitelist to form options only" and "Prefill", to improve the clarity and flexibility of filter and form configuration in the UI. [[1]](diffhunk://#diff-42034ce7174f68fbbc363e993dcc6eedbcf325b49858c5d56f2e07cd69ff92b9R61) [[2]](diffhunk://#diff-42034ce7174f68fbbc363e993dcc6eedbcf325b49858c5d56f2e07cd69ff92b9R75) [[3]](diffhunk://#diff-51fec4a06f3056dcdc870c0a9bab519ca60ae5116822ac740f2e5a1bee381d5eR58-R61)

**Minor and Supporting Changes:**

* Added a safe accessor method for retrieving the expected data container in `ListContainer`, replacing direct attribute access.
* Added a null-safe getter for list type descriptors in `ListTypeRegistry`.
* Removed redundant calls to `infer()` in event listeners, relying on the new lazy inference logic. [[1]](diffhunk://#diff-753576bd9cb7a2049a8001af49cc332fdfffd85325fb4e6a1edb7b25ba066348L38-L39) [[2]](diffhunk://#diff-e124ed2c36bff80e29810429d18599cfe14d8ca67f2d207a8033de409a6de106L38-L39)