### PR TITLE
Enhance query handling in FilterFormFactory and flare.js

### DIFF
--- a/public/frontend/flare.js
+++ b/public/frontend/flare.js
@@ -1,12 +1,13 @@
-((d, a, b, l) => {
-    b = () => d.querySelectorAll(`form${a}, ${a} form`).forEach(f => {
+((d, s, q, b, l) => {
+    b = () => d.querySelectorAll(`form${s}, ${s} form`).forEach(f => {
         if (f.method?.toUpperCase?.() !== 'GET') return;
         l = add => (e => {
             if (!f.action || !f.name) return;
             e.preventDefault();
+            const n = Array.from(f.querySelectorAll(q) || []).map(e => e.name);
             const url = new URL(f.action), del = [];
             for (const k of url.searchParams.keys()) {
-                if (k.startsWith(f.name + '[')) del.push(k);
+                if (k.startsWith(f.name + '[') || n.includes(k)) del.push(k);
             }
             del.forEach(key => url.searchParams.delete(key));
             add ? new FormData(f).forEach((v, k) => {
@@ -18,4 +19,4 @@
         f.addEventListener('reset', l(0));
     });
     d.readyState === 'loading' ? d.addEventListener('DOMContentLoaded', b) : b();
-})(document, '[data-flare-keep-query]');
+})(document, '[data-flare-form="keep-query"]', '[data-flare-form="query-field"]');

--- a/src/Form/Factory/FilterFormFactory.php
+++ b/src/Form/Factory/FilterFormFactory.php
@@ -41,7 +41,7 @@ readonly class FilterFormFactory
             'csrf_protection'    => false,
             'translation_domain' => 'flare_form',
             'attr' => [
-                'data-flare-keep-query' => 'true',
+                'data-flare-form' => 'keep-query',
             ],
         ];
 


### PR DESCRIPTION
This pull request updates how filter forms handle query parameters in both the frontend JavaScript and form factory. The main change is a switch from the generic `data-flare-keep-query` attribute to a more structured `data-flare-form="keep-query"` and the introduction of a dedicated selector for query fields. This improves clarity and maintainability in how forms preserve query parameters.

**Frontend JavaScript and form attribute updates:**

* Changed the attribute used to identify forms that should keep query parameters from `data-flare-keep-query` to `data-flare-form="keep-query"` in both the JavaScript selector and the form factory output (`flare.js`, `FilterFormFactory.php`). [[1]](diffhunk://#diff-2d3cfb6df1467600d5a8a9cc7e7540c4fbb6e224487faeca6d4d934c722cf819L21-R22) [[2]](diffhunk://#diff-5738b26ac00b956057d8526898bff3392cd163a29ec9de1ab8957ad81cdf89a1L44-R44)
* Updated the JavaScript logic in `flare.js` to use a new selector for query fields: `[data-flare-form="query-field"]`, ensuring that any fields with this attribute are properly managed when cleaning up query parameters. [[1]](diffhunk://#diff-2d3cfb6df1467600d5a8a9cc7e7540c4fbb6e224487faeca6d4d934c722cf819L1-R10) [[2]](diffhunk://#diff-2d3cfb6df1467600d5a8a9cc7e7540c4fbb6e224487faeca6d4d934c722cf819L21-R22)