### PR TITLE
Enhance documentation and refactor agent handling and interfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # AGENTS.md
 
-This file provides guidance AI coding agents, e.g., Claude Code (claude.ai/code), Gemini, and ChatGPT Codex, when working with code in this repository.
+This file provides guidance to AI coding agents, e.g., Claude Code (claude.ai/code), Gemini, and ChatGPT Codex, when working with code in this repository. `CLAUDE.md` is a symlink to this file — always edit `AGENTS.md`.
 
 ## Project
 
 **FLARE** (Filter, List, And REader) — a Symfony bundle for Contao CMS that replaces complex module setups with a unified List/Reader content element approach.
 
 - Namespace: `HeimrichHannot\FlareBundle\`
-- Requires PHP ^8.2, Symfony ^5.4/^6.0, Contao ^4.13/^5.0
+- Requires PHP ^8.2, Symfony ^5.4/^6.0/^7.0, Contao ^4.13/^5.0
 - Bundle Name: Contao Flare Bundle (`heimrichhannot/contao-flare-bundle`)
 - Type: Symfony Bundle for Contao CMS
 - Status: Active development (Beta/WIP).
@@ -18,13 +18,26 @@ The core execution flow is:
 
 ```
 ContentElement Controller
-  → EngineFactory → Engine
-    → Context (Interactive / Validation / Aggregation / Export)
-      → Projector (orchestrates query + filter execution)
-        → View (formats data for Twig template)
+  → EngineFactory (consumes a ListSpecification from src/Specification/)
+    → Engine
+      → Context (Interactive / Validation / Aggregation) — src/Engine/Context/
+        → Loader (src/Engine/Loader/) + Mods (src/Engine/Mod/)
+          → Projector (Interactive / Validation / Aggregation / Export) — orchestrates query + filter execution
+            → View (formats data for Twig template)
 ```
 
+Note: Contexts and Projectors/Views are separate axes — (Export Context/Projector/View are currently not implemented).
+
 The bundle follows standard Symfony Bundle architecture with deep Contao integration.
+
+**Notable subsystems** (beyond the flow above):
+- `src/Specification/` — `ListSpecification` / `FilterDefinition`, the declarative input to the engine
+- `src/Filter/`, `src/FilterElement/`, `src/FilterCollector/` — filter definition and execution
+- `src/Form/` — filter form building (FilterFormFactory etc.)
+- `src/Reader/` — reader/detail-page URL generation (`ReaderUrlGenerator`)
+- `src/InferPtable/` — parent-table inference for DCAs
+- `src/Integration/` — optional integrations (Codefog Tags, Terminal42 ChangeLanguage), wired via `config/integrations/*.yaml`
+- `src/EventListener/NamedDispatch/` — re-dispatches base events under dynamic names (see Event system below)
 
 **Key entry points:**
 - `src/HeimrichHannotFlareBundle.php` — bundle entry, registers compiler passes
@@ -36,13 +49,16 @@ The bundle follows standard Symfony Bundle architecture with deep Contao integra
 - `#[AsFilterElement(type: '...', palette: '...', formType: ...)]` — register a filter element
 - `#[AsListType(type: '...', dataContainer: '...', palette: '...')]` — register a list type
 - `#[AsFilterCallback(type, 'path.to.callback')]` — register a Contao DCA callback on a filter type
+- `#[AsListCallback(type, 'path.to.callback')]` — register a Contao DCA callback on a list type
 - `#[AsFilterInvoker]` — register a custom filter invocation handler
+
+(`AsFilterCallback` and `AsListCallback` both extend the `@internal` base attribute `AsFlareCallback`.)
 
 Attributes are in `src/DependencyInjection/Attribute/`, compiler passes in `src/DependencyInjection/Compiler/`.
 
-**Event system** — Events, some with aliased dispatch for targeted listening (`flare.form.{name}.build`, etc.). All events are in `src/Event/`. Prefer events over overriding services for customization.
+**Event system** — Events, some with aliased dispatch for targeted listening (`flare.form.{name}.build`, etc., implemented by the listeners in `src/EventListener/NamedDispatch/`). All events are in `src/Event/`. Prefer events over overriding services for customization.
 
-**Registry pattern** — `FilterElementRegistry`, `ListTypeRegistry`, `FilterInvokerRegistry`, `ProjectorRegistry` map type names to implementations.
+**Registry pattern** — Registries in `src/Registry/` map type names to implementations: `FilterElementRegistry`, `ListTypeRegistry`, `FilterInvokerRegistry`, `ProjectorRegistry`, `FilterCollectorRegistry`, `FlareCallbackRegistry`, `EngineModRegistry`.
 
 **Query safety** — `FilterQueryBuilder` (`src/Query/FilterQueryBuilder.php`) enforces parameterized queries. `TableAliasRegistry` (`src/Query/TableAliasRegistry.php`) manages table aliases and JOINs safely.
 
@@ -61,13 +77,26 @@ Attributes are in `src/DependencyInjection/Attribute/`, compiler passes in `src/
     *   `make php <args>` — Runs PHP commands (e.g., `make php bin/console debug:container`)
     *   `make composer <args>` — Runs Composer commands (e.g., `make composer install`)
     *   `make phpstan` — Runs PHPStan static analysis (level 5)
+    *   `make phpstan-pro` — Runs PHPStan Pro (web GUI, don't run as agent)
+    *   `make semgrep-sec` — Runs the Semgrep security scan
     *   `make docs-setup` — Sets up the Docusaurus environment in the `docs/` directory
     *   `make docs-remove` — Safely removes the documentation worktree
     *   `make help` — Lists all available make commands
+*   There is **no make target for Mago** (lint/format) — Mago runs in CI only.
 
 #### Static Analysis (PHPStan)
 *   **Config:** `phpstan.neon` — level 5, analyses `src/` (with a number of excludes)
 *   `src/Model/` is excluded because Contao models use magic `__get`/`__set` properties
+*   `src/Integration/Terminal42Languages/` is also excluded
+
+## Testing & CI
+
+*   **There is currently no test suite**: no `tests/` directory, no `phpunit.xml`, no test CI workflow — even though PHPUnit is in `require-dev` and `tests/` is referenced in `autoload-dev` and `mago.toml`. Don't look for tests or invent a `make test` target.
+*   CI workflows in `.github/workflows/`:
+    *   `phpstan.yaml` — PHPStan analysis
+    *   `mago.yaml` — Mago lint (`--minimum-fail-level note`, PHP 8.2–8.5)
+    *   `compatibility.yaml` — `composer validate` + dependency-resolution matrix (PHP 8.2–8.5 × Contao 4.13/5.x)
+    *   `security.yaml` — `composer audit` + Semgrep, also on a weekly schedule
 
 ## Key Directories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/contao/templates/content_element/flare_listview/list_only.html.twig
+++ b/contao/templates/content_element/flare_listview/list_only.html.twig
@@ -1,10 +1,12 @@
 {% extends '@Contao/block_searchable.html5' %}
 
+{% set flare_list = flare.createView %}
+
 {% block content %}
 
     {% block list %}
 
-        {% for entry in flare.entries %}
+        {% for entry in flare_list.entries %}
             <details>
                 {# (entry.headline is defined) ? (entry.headline|flare_fmt_headline_value|default('<' ~ loop.index ~ '>')) : #}
                 <summary>#{{ entry.id }} {{ entry.title ?? (entry.email ?? entry.alias ?? ('<' ~ loop.index ~ '>')) }}</summary>

--- a/src/DependencyInjection/Attribute/AsFilterInvoker.php
+++ b/src/DependencyInjection/Attribute/AsFilterInvoker.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace HeimrichHannot\FlareBundle\DependencyInjection\Attribute;
 
+/**
+ * @deprecated Define filter invocation via the filter element's `__invoke` method instead. Removal pending for v0.2.
+ */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AsFilterInvoker
 {

--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -56,7 +56,7 @@ final class Engine
     /**
      * @api
      */
-    public function addMod(string $modType, array $config): self
+    public function addMod(string $modType, array $config = []): self
     {
         $this->mods[] = [
             'type' => $modType,

--- a/src/Engine/Mod/ModInterface.php
+++ b/src/Engine/Mod/ModInterface.php
@@ -6,14 +6,11 @@ namespace HeimrichHannot\FlareBundle\Engine\Mod;
 
 use HeimrichHannot\FlareBundle\Engine\Engine;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 #[AutoconfigureTag('flare.engine_mod')]
 interface ModInterface
 {
     public static function getType(): string;
-
-    public function configureOptions(OptionsResolver $resolver): void;
 
     public function apply(Engine $engine, array $options): void;
 }

--- a/src/Query/QueryHelperTrait.php
+++ b/src/Query/QueryHelperTrait.php
@@ -6,11 +6,6 @@ namespace HeimrichHannot\FlareBundle\Query;
 
 trait QueryHelperTrait
 {
-    public function column(string $column, string $alias = TableAliasRegistry::ALIAS_MAIN): string
-    {
-        return sprintf('%s.%s', $alias, $column);
-    }
-
     public function makeJoinOn(string $alias1, string $col1, string $alias2, string $col2): string
     {
         return sprintf('%s.%s = %s.%s', $alias1, $col1, $alias2, $col2);


### PR DESCRIPTION
# Docs & agents update, list-view cleanup, `AsFilterInvoker` deprecation

## Summary

Documentation-focused PR with a few small API cleanups. Adds comprehensive AI-agent guidance via `AGENTS.md` (with `CLAUDE.md` as a symlink), refactors the list-only Twig template to use the engine's view API, deprecates `#[AsFilterInvoker]`, and removes unused methods from `ModInterface` and `QueryHelperTrait`.

## Changes

### Documentation

- **`AGENTS.md`** — substantially expanded guidance for AI coding agents:
  - Corrected the architecture flow diagram (adds `ListSpecification`, `Loader`, `Mods`; clarifies that Contexts and Projectors/Views are separate axes and that the Export context/projector/view are not yet implemented)
  - New "Notable subsystems" section (`src/Specification/`, `src/Filter*/`, `src/Form/`, `src/Reader/`, `src/InferPtable/`, `src/Integration/`, `src/EventListener/NamedDispatch/`)
  - Documented `#[AsListCallback]` and the `@internal` `AsFlareCallback` base attribute
  - Complete registry list (`FilterCollectorRegistry`, `FlareCallbackRegistry`, `EngineModRegistry` added)
  - New "Testing & CI" section: explicitly states there is no test suite yet and lists all CI workflows
  - Tooling additions (`make phpstan-pro`, `make semgrep-sec`; note that Mago runs in CI only) and updated PHPStan excludes
  - Updated Symfony version range to include `^7.0`
- **`CLAUDE.md`** — added as a symlink to `AGENTS.md` so Claude Code picks up the same instructions (edit `AGENTS.md` only)

### List handling / templates

- **`list_only.html.twig`** — now creates the view explicitly via `{% set flare_list = flare.createView %}` and iterates `flare_list.entries` instead of `flare.entries`

### Deprecations & API cleanup

- **`#[AsFilterInvoker]`** — deprecated; filter invocation should be defined via the filter element's `__invoke` method instead. Removal planned for v0.2.
- **`Engine::addMod()`** — `$config` parameter now defaults to `[]`
- **`ModInterface`** — removed the unused `configureOptions(OptionsResolver $resolver)` method (and the OptionsResolver dependency from the interface)
- **`QueryHelperTrait`** — removed the unused `column()` helper

## Breaking changes

- Removing `ModInterface::configureOptions()` breaks custom engine mods that implement it (mods should drop the method).
- Templates relying on `flare.entries` in `list_only.html.twig` follow a new pattern; custom templates are unaffected but should adopt `flare.createView` going forward.

## Notes

- No test suite exists yet; verified via PHPStan/CI workflows.
